### PR TITLE
feat: 웹뷰 뒤로가기 및 앱 종료 확인 모달 구현

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -259,15 +259,53 @@ class _TrackFollowsPageState extends State<TrackFollowsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Colors.white,
-        elevation: 0,
-        toolbarHeight: 0,
-      ),
-      body: WebViewWidget(
-        controller: controller,
+    return PopScope(
+      canPop: false,
+      onPopInvoked: (didPop) async {
+        if (didPop) return;
+        // 웹뷰에서 뒤로갈 수 있는지 확인
+        final canGoBack = await controller.canGoBack();
+        if (canGoBack) {
+          // 웹뷰에서 뒤로가기
+          await controller.goBack();
+        } else {
+          final shouldExit = await _showExitDialog();
+          if (shouldExit && context.mounted) {
+            Navigator.of(context).pop();
+          }
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          toolbarHeight: 0,
+        ),
+        body: WebViewWidget(
+          controller: controller,
+        ),
       ),
     );
+  }
+
+  Future<bool> _showExitDialog() async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('앱 종료'),
+            content: const Text('앱을 종료하시겠습니까?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('종료'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
   }
 }


### PR DESCRIPTION
# 구현
웹뷰 뒤로가기 및 앱 종료 확인 모달 구현

## 📌 문제점
- 웹뷰에서 뒤로가기 버튼 클릭시 앱이 바로 종료됨
- Next.js router.push/Link로 이동한 페이지에서 뒤로가기 불가

### ✨ 구현 기능

- 뒤로가기 처리
  - `PopScope`를 이용한 안드로이드 뒤로가기 인터셉트
- 앱 종료 확인 모달 구현

### 스크린샷
![image](https://github.com/user-attachments/assets/c970ea5e-76a1-496f-945c-d7008190708a)
